### PR TITLE
Multi snippet support

### DIFF
--- a/notes/bash-case-statement.md
+++ b/notes/bash-case-statement.md
@@ -1,11 +1,12 @@
 ---
 subject: bash
-syntax: bash
-snippet: |
-  case $var in
-    one) echo "hello" ;;
-    two) echo "world" ;;
-  esac
+snippets:
+  - syntax: bash
+    content: |
+      case $var in
+        one) echo "hello" ;;
+        two) echo "world" ;;
+      esac
 ---
 
 # Case statement

--- a/notes/bash-get-line-number-of-nth-match.md
+++ b/notes/bash-get-line-number-of-nth-match.md
@@ -28,7 +28,7 @@ title: some frontmatter
 ```
 
 ```bash
-grep '^---$' -m 2 -n input.md | tail -1 | cut -d ":" -f 2
+grep '^---$' -m 2 -n input.md | tail -1 | cut -d ":" -f 1
 ```
 
 This gets the job done, but it invokes a number of subshells, reducing

--- a/notes/bash-get-line-number-of-nth-match.md
+++ b/notes/bash-get-line-number-of-nth-match.md
@@ -1,12 +1,13 @@
 ---
 subject: bash
-syntax: bash
 tags:
   - scripting
   - grep
   - awk
-snippet: |
-  awk '/PATTERN/ && (++c == NUM) { print NR; exit }' INPUT
+snippets:
+  - syntax: bash
+    content: |
+      awk '/PATTERN/ && (++c == NUM) { print NR; exit }' INPUT
 ---
 
 # Getting the line number of the nth match
@@ -36,3 +37,5 @@ performance. An alternative using `awk` may be less I/O intensive:
 ```bash
 awk '/^---$/ && (++c == 2) { print NR; exit }' input.md
 ```
+
+[Source](https://stackoverflow.com/questions/57044203/how-to-get-the-line-number-of-nth-match#comment100617725_57044437)

--- a/notes/bash-getopts-flags.md
+++ b/notes/bash-getopts-flags.md
@@ -1,43 +1,44 @@
 ---
 subject: bash
-syntax: bash
-snippet: |
-  ERROR="Bad usage, see ${0##*/} -h"
+snippets:
+  - syntax: bash
+    content: |
+      ERROR="Bad usage, see ${0##*/} -h"
 
-  read -r -d "" USAGE <<EOF
-  Short description
+      read -r -d "" USAGE <<EOF
+      Short description
 
-  Usage: ${0##*/} [-fh]
-    -f ARG      Do something
-    -h          Show usage
+      Usage: ${0##*/} [-fh]
+        -f ARG      Do something
+        -h          Show usage
 
-  Example:
-    ${0##*/} -f my-arg
+      Example:
+        ${0##*/} -f my-arg
 
-  EOF
+      EOF
 
-  set -eo pipefail
+      set -eo pipefail
 
-  if [ "$1" = "--help" ]; then
-    echo "$USAGE" && exit 0
-  fi
+      if [ "$1" = "--help" ]; then
+        echo "$USAGE" && exit 0
+      fi
 
-  while getopts f:h opt; do
-    case $opt in
-      f) VAR=$OPTARG                         ;;
-      h) echo "$USAGE" && exit 0             ;;
-      *) echo "$ERROR" && exit 1             ;;
-    esac
-  done
+      while getopts f:h opt; do
+        case $opt in
+          f) VAR=$OPTARG                         ;;
+          h) echo "$USAGE" && exit 0             ;;
+          *) echo "$ERROR" && exit 1             ;;
+        esac
+      done
 
-  POS_ARG=${*:$OPTIND:1}
+      POS_ARG=${*:$OPTIND:1}
 
-  OTHER_ARGS=${*:$OPTIND+1}
+      OTHER_ARGS=${*:$OPTIND+1}
 
-  if [ -n "$OTHER_ARGS" ]; then
-    echo "ERROR: Unprocessed positional arguments: $OTHER_ARGS"
-    exit 1
-  fi
+      if [ -n "$OTHER_ARGS" ]; then
+        echo "ERROR: Unprocessed positional arguments: $OTHER_ARGS"
+        exit 1
+      fi
 ---
 
 # Getopts

--- a/notes/bash-sed-awk-read-between-markers.md
+++ b/notes/bash-sed-awk-read-between-markers.md
@@ -1,12 +1,22 @@
 ---
 subject: bash
-syntax: bash
 tags:
   - scripting
   - sed
   - awk
-snippet: |
-  sed -n '/^---$/,/^---$/ { /^---$/d; p; }'
+snippets:
+  - syntax: bash
+    content: |
+      sed -n '/^---$/,/^---$/ { /^---$/d; p; }'
+  - syntax: bash
+    content: |
+      awk '/^---$/{flag =! flag; next}flag'
+  - syntax: bash
+    content: |
+      awk '/^---$/{if (flag == 0) {flag = 1;next} else {exit}}flag'
+  - syntax: bash
+    content: |
+      awk '/start/{flag=1;next}/end/{flag=0}flag'
 ---
 
 # Reading content between markers

--- a/notes/bash-substring-contains.md
+++ b/notes/bash-substring-contains.md
@@ -1,10 +1,11 @@
 ---
 subject: bash
-syntax: bash
-snippet: |
-  if [ "${var#*substring}" != "${var}" ]; then
-    # do stuff
-  fi
+snippets:
+  - syntax: bash
+    content: |
+      if [ "${var#*substring}" != "${var}" ]; then
+        # do stuff
+      fi
 ---
 
 # Bash substring

--- a/notes/css-box-sizing-border-box.md
+++ b/notes/css-box-sizing-border-box.md
@@ -1,12 +1,13 @@
 ---
 subject: css
-syntax: css
-snippet: |
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
+snippets:
+  - syntax: css
+    content: |
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
 ---
 
 # `box-sizing: border-box`

--- a/notes/css-currentcolor.md
+++ b/notes/css-currentcolor.md
@@ -3,9 +3,10 @@ subject: css
 tags:
   - color
   - explicit
-syntax: css
-snippet: |
-  border: 2px solid currentColor;
+snippets:
+  - syntax: css
+    content: |
+      border: 2px solid currentColor;
 ---
 
 # The `currentColor` keyword

--- a/notes/css-margin-auto.md
+++ b/notes/css-margin-auto.md
@@ -1,13 +1,14 @@
 ---
 subject: css
-syntax: css
 tags:
   - margin
   - layout
   - centering
-snippet: |
-  margin-left: auto;
-  margin-right: auto;
+snippets:
+  - syntax: css
+    content: |
+      margin-left: auto;
+      margin-right: auto;
 ---
 
 # Using `margin: auto;` for centering

--- a/notes/css-visually-hidden.md
+++ b/notes/css-visually-hidden.md
@@ -1,19 +1,20 @@
 ---
 subject: css
-syntax: css
 tags:
   - a11y
   - accessibility
-snippet: |
-  .visually-hidden:not(:focus):not(:active) {
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+snippets:
+  - syntax: css
+    content: |
+      .visually-hidden:not(:focus):not(:active) {
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+      }
 ---
 
 # Hiding elements

--- a/notes/git-config-conditional-includes-directory.md
+++ b/notes/git-config-conditional-includes-directory.md
@@ -1,0 +1,42 @@
+---
+subject: git
+tags:
+  - config
+  - work
+snippets:
+  - syntax: conf
+    content: |
+      [includeIf "gitdir:work/"]
+        path = config-work
+---
+
+# Conditional git config includes
+
+Sometimes we want to use different git configurations for different
+sub-directories. For client work, for example, we might want to use another
+email address for our commits. While this could be accomplished by modifying
+the local git configuration in each repository, there is another way to solve
+the problem in one stroke: conditional includes.
+
+Using the `include` keyword, we can include other configuration files. With
+`includeIf`, we can supply a condition that must be met. There are many
+options, but one of the most useful ones is `gitdir`. If all work related
+projects are contained in a directory called `work` (be that in `~/work` or
+`~/dev/work` or somewhere else entirely), we can use this statement to include
+work-specific configuration for those projects:
+
+```conf
+[includeIf "gitdir:work/"]
+  path = config-work
+```
+
+The path to the config file to include is relative to the main configuration
+file, unless an absolute path is given. Within it, we can override settings
+from the main file, e.g.:
+
+```conf
+[user]
+  email = me@work.com
+```
+
+Source: `man git-config`

--- a/notes/git-get-current-branch.md
+++ b/notes/git-get-current-branch.md
@@ -1,8 +1,9 @@
 ---
 subject: git
-syntax: bash
-snippet: |
-  git rev-parse --abbrev-ref HEAD
+snippets:
+  - syntax: bash
+    content: |
+      git rev-parse --abbrev-ref HEAD
 ---
 
 # Git - name of current branch

--- a/notes/note-template.md
+++ b/notes/note-template.md
@@ -1,12 +1,13 @@
 ---
 subject: SUBJECT
-syntax: SYNTAX
 tags:
   - list
   - of
   - tags
-snippet: |
-  put a (multiline) snippet here
+snippets:
+  - syntax: SYNTAX
+    content: |
+      put a (multiline) snippet here
 ---
 
 # Docs

--- a/notes/vim-open-files-in-splits.md
+++ b/notes/vim-open-files-in-splits.md
@@ -3,8 +3,10 @@ subject: vim
 syntax: bash
 tags:
   - vim
-snippet: |
-  vim -o *.sh
+snippets:
+  - syntax: bash
+    content: |
+      vim -o *.sh
 ---
 
 # Opening a list of files in split windows

--- a/notes_entry.sh
+++ b/notes_entry.sh
@@ -7,7 +7,8 @@ file=$(./notes_tool.sh list-with-tags | fzf \
   --preview './notes_tool.sh preview {1}' \
   --preview-window 'right:80:wrap' \
   --bind 'alt-up:preview-up,alt-down:preview-down' \
-  --bind 'ctrl-y:execute(./notes_tool.sh copy {1})' \
+  --bind 'ctrl-y:execute-silent(./notes_tool.sh copy {1})+abort' \
+  --bind 'ctrl-n:execute-silent(./notes_tool.sh next-snippet {1})+refresh-preview' \
   --bind 'alt-enter:print-query' \
   --print-query | tail -1 | cut -d " " -f 1
 )

--- a/notes_tool.sh
+++ b/notes_tool.sh
@@ -8,6 +8,7 @@ CACHE_DIR=${XDG_CACHE_HOME:-~/.cache}/notes
 NOTES_DIR_STAT_FILE=${CACHE_DIR}/notes_dir_stat
 LIST_WITH_TAGS_CACHE=${CACHE_DIR}/list_with_tags
 NOTES_SNIPPET_IDX_DIR=${CACHE_DIR}/snippet_idx
+LAST_DOCS_PRINTED=${CACHE_DIR}/last_docs_printed
 
 if [ ! -d "$NOTES_SNIPPET_IDX_DIR" ]; then
   mkdir -p "$NOTES_SNIPPET_IDX_DIR"
@@ -57,6 +58,11 @@ read_frontmatter() {
 
 print_docs() {
   local boundary
+  if [ -f "$LAST_DOCS_PRINTED" ]; then
+    echo "$(<"$LAST_DOCS_PRINTED")"
+    rm "$LAST_DOCS_PRINTED"
+    return
+  fi
   boundary=$(frontmatter_boundary "$1")
   boundary=$((boundary+1))
   sed -n "${boundary},$ p" "$1" | mdcat
@@ -104,6 +110,8 @@ next_snippet() {
   fi
 
   write_snippet_idx "$1" "$next_idx"
+  print_docs "$1" > "$LAST_DOCS_PRINTED.tmp"
+  mv "$LAST_DOCS_PRINTED.tmp" "$LAST_DOCS_PRINTED"
 }
 
 print_snippet() {


### PR DESCRIPTION
Restructures the snippet section of the note frontmatter to allow for multiple snippets tied to each note. With the preview window open, the selected snippet can be cycled using `ctrl-n`. There is some caching of the documentation output involved to reduce flickering. I'm beginning to think this project is outgrowing its current bash implementation.
